### PR TITLE
try to fix Rules Mode, Core Update

### DIFF
--- a/V2RayX/AppDelegate.m
+++ b/V2RayX/AppDelegate.m
@@ -538,12 +538,8 @@ static AppDelegate *appDelegate;
         fullConfig[@"dns"][@"servers"] = @[@"localhost"];
     }
     if (proxyMode == rules) {
-        [fullConfig[@"routing"][@"settings"][@"rules"][0][@"ip"] addObject:@"geoip:cn"];
-        [fullConfig[@"routing"][@"settings"][@"rules"]
-         addObject:@{ @"domain": @[@"geosite:cn"],
-                      @"outboundTag": @"direct",
-                      @"type": @"field",
-                     }];
+        [fullConfig[@"routing"][@"settings"][@"rules"][0][@"domain"] addObject:@"geosite:cn"];
+        [fullConfig[@"routing"][@"settings"][@"rules"][1][@"ip"] addObject:@"geoip:cn"];
     } else if (proxyMode == manual) {
         fullConfig[@"routing"][@"settings"][@"rules"] = @[];
     }

--- a/V2RayX/Info.plist
+++ b/V2RayX/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>192</string>
+	<string>193</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>LSUIElement</key>

--- a/V2RayX/config-sample.plist
+++ b/V2RayX/config-sample.plist
@@ -155,24 +155,24 @@
 			<key>rules</key>
 			<array>
 				<dict>
-					<key>ip</key>
-					<array>
-						<string>geoip:private</string>
-					</array>
-					<key>outboundTag</key>
-					<string>direct</string>
 					<key>type</key>
 					<string>field</string>
-				</dict>
-				<dict>
 					<key>outboundTag</key>
 					<string>direct</string>
 					<key>domain</key>
 					<array>
 						<string>localhost</string>
 					</array>
+				</dict>
+				<dict>
 					<key>type</key>
 					<string>field</string>
+					<key>outboundTag</key>
+					<string>direct</string>
+					<key>ip</key>
+					<array>
+						<string>geoip:private</string>
+					</array>
 				</dict>
 			</array>
 		</dict>

--- a/V2RayX/dlcore.sh
+++ b/V2RayX/dlcore.sh
@@ -1,4 +1,4 @@
-VERSION="v3.22"
+VERSION="v3.23"
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 BOLD='\033[1m'


### PR DESCRIPTION
看了一下V2Ray的[官方用户手册](https://www.v2ray.com/chapter_02/03_routing.html)
```
rules: 对应一个数组，数组中每个一个元素是一个规则。对于每一个连接，路由将根据这些规则依次进行判断
```
可以判断rules的每个数组之间是有顺序的，按照原配置（即ip规则在上，domain在下），会直接使用ip进行匹配而忽略domain规则，此举疑似会导致处理效率下降：
```
"rules" : [
         {
          "type" : "field",
          "outboundTag" : "direct",
          "ip" : [
            "geoip:private"
          ]
        },
        {
          "domain" : [
            "localhost"
          ],
          "type" : "field",
          "outboundTag" : "direct"
        }
      ]
```
修改后对掉了两个数组的位置，我之前反馈的某些网站打开极其缓慢的问题也正常了。

--------

另外就是[v3.23](https://www.v2ray.com/chapter_00/01_versions.html)已经支持引入外源规则文件了，是否还有保留pac模式的必要呢～