### PR TITLE
TLS optimized（有bug）

### DIFF
--- a/V2RayX/ConfigWindowController.h
+++ b/V2RayX/ConfigWindowController.h
@@ -52,7 +52,8 @@
 //tls fields
 @property (weak) IBOutlet NSButton *tlsUseButton;
 @property (weak) IBOutlet NSButton *tlsAiButton;
-@property (weak) IBOutlet NSTextField *tlsSnField;
+@property (weak) IBOutlet NSButton *tlsAllowInsecureCiphersButton;
+@property (weak) IBOutlet NSTextField *tlsAlpnField;
 
 //mux fields
 @property (weak) IBOutlet NSButton *muxEnableButton;

--- a/V2RayX/Info.plist
+++ b/V2RayX/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>315</string>
+	<string>353</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>LSUIElement</key>

--- a/V2RayX/ServerProfile.h
+++ b/V2RayX/ServerProfile.h
@@ -28,6 +28,7 @@ typedef enum NetWorkType : NSUInteger {
 + (ServerProfile* _Nullable )readFromAnOutboundDic:(NSDictionary*)outDict;
 + (NSArray*)profilesFromJson:(NSDictionary*)outboundJson;
 -(ServerProfile*)deepCopy;
+
 @property (nonatomic) NSString* address;
 @property (nonatomic) NSUInteger port;
 @property (nonatomic) NSString* userId;

--- a/V2RayX/ServerProfile.m
+++ b/V2RayX/ServerProfile.m
@@ -10,6 +10,9 @@
 
 @implementation ServerProfile
 
+NSString * address;
+
+
 - (ServerProfile*)init {
     self = [super init];
     if (self) {
@@ -26,7 +29,9 @@
                                   @"security": @"none",
                                   @"tlsSettings": @{
                                           @"serverName": @"server.cc",
-                                          @"allowInsecure": [NSNumber numberWithBool:NO]
+                                          @"alpn": @[@"http/1.1"],
+                                          @"allowInsecure": [NSNumber numberWithBool:NO],
+                                          @"allowInsecureCiphers": [NSNumber numberWithBool:NO]
                                           },
                                   @"tcpSettings": @{
                                           @"header": @{

--- a/V2RayX/transportWindow.xib
+++ b/V2RayX/transportWindow.xib
@@ -24,7 +24,8 @@
                 <outlet property="tcpHeaderCusButton" destination="vXV-c6-ZJ3" id="0mg-Po-v3S"/>
                 <outlet property="tfoEnableButton" destination="Y7H-QP-cdh" id="0GO-ib-yPH"/>
                 <outlet property="tlsAiButton" destination="l3Z-uk-KBr" id="FUU-TQ-bqK"/>
-                <outlet property="tlsSnField" destination="nw2-5m-34B" id="8nF-Yj-QgG"/>
+                <outlet property="tlsAllowInsecureCiphersButton" destination="L3V-ES-nEc" id="GcW-j6-49f"/>
+                <outlet property="tlsAlpnField" destination="ueg-ns-8xA" id="Oh0-O8-IOk"/>
                 <outlet property="tlsUseButton" destination="n0X-Fy-rS1" id="8sl-p5-7bG"/>
                 <outlet property="transportWindow" destination="QvC-M9-y7g" id="EGp-nT-Eil"/>
                 <outlet property="wsHeaderField" destination="5WV-Rv-Aia" id="rVD-9N-x89"/>
@@ -319,7 +320,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <clipView key="contentView" ambiguous="YES" drawsBackground="NO" id="Ijl-Ha-SNR">
                                                 <rect key="frame" x="1" y="1" width="311" height="55"/>
-                                                <autoresizingMask key="autoresizingMask"/>
+                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <textView ambiguous="YES" importsGraphics="NO" richText="NO" verticallyResizable="YES" allowsCharacterPickerTouchBarItem="NO" allowsUndo="YES" allowsNonContiguousLayout="YES" textCompletion="NO" spellingCorrection="YES" id="5WV-Rv-Aia">
                                                         <rect key="frame" x="0.0" y="0.0" width="311" height="55"/>
@@ -430,15 +431,32 @@
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="l3Z-uk-KBr">
-                                            <rect key="frame" x="15" y="63" width="110" height="18"/>
+                                            <rect key="frame" x="15" y="50" width="132" height="18"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <buttonCell key="cell" type="check" title="Allow insecure" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Rxl-Fh-p8u">
+                                            <buttonCell key="cell" type="check" title="TLS allowInsecure" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Rxl-Fh-p8u">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
                                             </buttonCell>
                                         </button>
+                                        <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="L3V-ES-nEc">
+                                            <rect key="frame" x="238" y="85" width="179" height="18"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="check" title="TLS allowInsecureCiphers" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="tGs-7I-7qD">
+                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                            </buttonCell>
+                                        </button>
+                                        <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ueg-ns-8xA">
+                                            <rect key="frame" x="286" y="47" width="96" height="22"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="VDm-Wv-O7F">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
                                         <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="n0X-Fy-rS1">
-                                            <rect key="frame" x="15" y="98" width="73" height="18"/>
+                                            <rect key="frame" x="15" y="85" width="73" height="18"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <buttonCell key="cell" type="check" title="Use TLS" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="cY9-cQ-T9f">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -449,21 +467,12 @@
                                             </connections>
                                         </button>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Nhc-Gl-Mct">
-                                            <rect key="frame" x="15" y="27" width="87" height="17"/>
+                                            <rect key="frame" x="238" y="50" width="34" height="17"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Server Name:" id="eb7-WI-WKe">
+                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="alpn:" id="eb7-WI-WKe">
                                                 <font key="font" metaFont="system"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="nw2-5m-34B">
-                                            <rect key="frame" x="108" y="25" width="213" height="22"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="573-7w-T3E">
-                                                <font key="font" metaFont="system"/>
-                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
                                     </subviews>


### PR DESCRIPTION
1. 删去了tls server domain的field
> 我看了#33，但是实在是没有想到有什么地方`server address`和`tls server domain`不一样的情况，而且`vmess url`并不传递`tls server domain`参数，如果未来支持订阅的话将导致所有的tls节点需要手动配置。同时win端的gui也没有允许手动配置该参数
2. 支持`allowInsecureCiphers`和`alpn`配置

## Bug 如下
alpn的配置会被转义
`"alpn": ["http/1.1"],`
被转义为
`"alpn": ["http\/1.1"],`

