### PR TITLE
remove aes-128-cfb, core updated

### DIFF
--- a/V2RayX/ConfigWindow.xib
+++ b/V2RayX/ConfigWindow.xib
@@ -381,12 +381,11 @@
                                 <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Dbo-ml-2p8">
                                     <rect key="frame" x="73" y="71" width="214" height="26"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                    <popUpButtonCell key="cell" type="push" title="aes-128-cfb" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="max-qR-nJy" id="Jfz-Zt-LZn">
+                                    <popUpButtonCell key="cell" type="push" title="aes-128-gcm" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="92F-Fh-RHW" id="Jfz-Zt-LZn">
                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="menu"/>
                                         <menu key="menu" id="Ziq-n1-gks">
                                             <items>
-                                                <menuItem title="aes-128-cfb" state="on" id="max-qR-nJy"/>
                                                 <menuItem title="aes-128-gcm" id="92F-Fh-RHW"/>
                                                 <menuItem title="chacha20-poly1305" id="1SH-Qb-KKl"/>
                                                 <menuItem title="auto (suggested)" id="clS-ih-hzy">

--- a/V2RayX/ConfigWindowController.m
+++ b/V2RayX/ConfigWindowController.m
@@ -629,6 +629,7 @@
 
 - (IBAction)useTLS:(id)sender {
     [_tlsAiButton setEnabled:[_tlsUseButton state]];
+    [_tlsAllowInsecureCiphersButton setEnabled:[_tlsUseButton state]];
 }
 
 - (IBAction)transportHelp:(id)sender {

--- a/V2RayX/Info.plist
+++ b/V2RayX/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>369</string>
+	<string>383</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>LSUIElement</key>

--- a/V2RayX/ServerProfile.h
+++ b/V2RayX/ServerProfile.h
@@ -9,7 +9,6 @@
 #import "AppDelegate.h"
 
 typedef enum SecurityType : NSUInteger {
-    aes_128_cfb,
     aes_128_gcm,
     chacha20_poly130,
     auto_,

--- a/V2RayX/ServerProfile.m
+++ b/V2RayX/ServerProfile.m
@@ -80,7 +80,7 @@ NSString * address;
     }
     NSMutableArray* profiles = [[NSMutableArray alloc] init];
     NSDictionary *netWorkDict = @{@"tcp": @0, @"kcp": @1, @"ws":@2, @"http":@3 };
-    NSDictionary *securityDict = @{@"aes-128-cfb":@0, @"aes-128-gcm":@1, @"chacha20-poly1305":@2, @"auto":@3, @"none":@4};
+    NSDictionary *securityDict = @{@"aes-128-gcm":@0, @"chacha20-poly1305":@1, @"auto":@2, @"none":@3};
     NSString* sendThrough = nilCoalescing(outboundJson[@"sendThrough"], @"0.0.0.0");
     if (![[outboundJson valueForKeyPath:@"settings.vnext"] isKindOfClass:[NSArray class]]) {
         return @[];
@@ -152,7 +152,7 @@ NSString * address;
                                   @{
                                       @"id": userId != nil ? [userId stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]]: @"",
                                       @"alterId": [NSNumber numberWithUnsignedInteger:alterId],
-                                      @"security": @[@"aes-128-cfb", @"aes-128-gcm", @"chacha20-poly1305", @"auto", @"none"][security],
+                                      @"security": @[@"aes-128-gcm", @"chacha20-poly1305", @"auto", @"none"][security],
                                       @"level": [NSNumber numberWithUnsignedInteger:level]
                                       }
                                   ]

--- a/V2RayX/dlcore.sh
+++ b/V2RayX/dlcore.sh
@@ -1,4 +1,4 @@
-VERSION="v3.50"
+VERSION="v4.6.0"
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 BOLD='\033[1m'

--- a/V2RayX/transportWindow.xib
+++ b/V2RayX/transportWindow.xib
@@ -238,7 +238,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <clipView key="contentView" ambiguous="YES" drawsBackground="NO" id="74S-96-NuK">
                                                 <rect key="frame" x="1" y="1" width="441" height="99"/>
-                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                <autoresizingMask key="autoresizingMask"/>
                                                 <subviews>
                                                     <textView ambiguous="YES" importsGraphics="NO" richText="NO" verticallyResizable="YES" allowsCharacterPickerTouchBarItem="NO" allowsUndo="YES" allowsNonContiguousLayout="YES" textCompletion="NO" id="dcF-wv-cmU">
                                                         <rect key="frame" x="0.0" y="0.0" width="441" height="99"/>
@@ -320,7 +320,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <clipView key="contentView" ambiguous="YES" drawsBackground="NO" id="Ijl-Ha-SNR">
                                                 <rect key="frame" x="1" y="1" width="311" height="55"/>
-                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                <autoresizingMask key="autoresizingMask"/>
                                                 <subviews>
                                                     <textView ambiguous="YES" importsGraphics="NO" richText="NO" verticallyResizable="YES" allowsCharacterPickerTouchBarItem="NO" allowsUndo="YES" allowsNonContiguousLayout="YES" textCompletion="NO" spellingCorrection="YES" id="5WV-Rv-Aia">
                                                         <rect key="frame" x="0.0" y="0.0" width="311" height="55"/>
@@ -372,8 +372,8 @@
                                     </subviews>
                                 </view>
                             </tabViewItem>
-                            <tabViewItem label="http/2" identifier="" id="3a5-FH-jdA">
-                                <view key="view" id="Kim-Ta-kSs">
+                            <tabViewItem label="HTTP/2" identifier="" id="3a5-FH-jdA">
+                                <view key="view" ambiguous="YES" id="Kim-Ta-kSs">
                                     <rect key="frame" x="10" y="33" width="477" height="135"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
@@ -426,7 +426,7 @@
                                 </view>
                             </tabViewItem>
                             <tabViewItem label="TLS" identifier="" id="sCQ-Dt-YCG">
-                                <view key="view" ambiguous="YES" id="yce-Q2-W28">
+                                <view key="view" id="yce-Q2-W28">
                                     <rect key="frame" x="10" y="33" width="477" height="135"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
@@ -478,7 +478,7 @@
                                     </subviews>
                                 </view>
                             </tabViewItem>
-                            <tabViewItem label="Other" identifier="" id="QwI-cq-3dE">
+                            <tabViewItem label="···" identifier="" id="QwI-cq-3dE">
                                 <view key="view" id="qEg-0O-lVX">
                                     <rect key="frame" x="10" y="33" width="477" height="135"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>


### PR DESCRIPTION
1. remove aes-128-cfb because of security
2. core update to v4.6.0
3. tlsAllowInsecureCiphers can be used after switching on useTLS