### PR TITLE
del def server address

### DIFF
--- a/V2RayX/ServerProfile.m
+++ b/V2RayX/ServerProfile.m
@@ -12,7 +12,7 @@
 - (ServerProfile*)init {
     self = [super init];
     if (self) {
-        [self setAddress:@"server.cc"];
+        [self setAddress:@""];
         [self setPort:10086];
         [self setUserId:@"00000000-0000-0000-0000-000000000000"];
         [self setAlterId:64];
@@ -24,7 +24,7 @@
         [self setStreamSettings:@{
                                   @"security": @"none",
                                   @"tlsSettings": @{
-                                          @"serverName": @"server.cc",
+                                          @"serverName": @"",
                                           @"alpn": @[@"http/1.1"],
                                           @"allowInsecure": [NSNumber numberWithBool:NO],
                                           @"allowInsecureCiphers": [NSNumber numberWithBool:NO]


### PR DESCRIPTION
删除默认服务器地址，通过vmess链接导入配置的 tls 为默认地址无法使用。